### PR TITLE
forward compatibility with ramda 0.x versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-ramda",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ramda modularized builds without the hassle",
   "repository": "megawac/babel-plugin-ramda",
   "author": "Graeme Yeates (github.com/megawac) <megawac@gmail.com>",
@@ -22,7 +22,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "ramda": "^0.19.1"
+    "ramda": "^0.20.1"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "ramda": "^0.20.1"
+    "ramda": "^0.x"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
I'm using ramda 0.20.1 version in my project, using the tryCatch function (which was added in 0.20.0) and this plugin fails because it can't find this function.

The problem is that its has its own node_modules with ramda 0.19.1 instead of using the top level ramda 0.20.1 because inside package.json the version specified as `^0.19.1` which allows only patch updates.

This plugin uses ramda only to figure out the interface (exposed functions) so its ok to have forward compatibility with at least ramda's 0.x versions. Otherwise, there will be need to update the plugin for every ramda's minor update and there is no benefits in doing that as it looks from my perspective.