### PR TITLE
bugfix(IdentifierVisitor): add checks parent node for Identifier path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,10 +65,10 @@ export default function({ types: t }) {
         path.replaceWith({ type: newNode.type, name: newNode.name });
       },
       Identifier(path) {
-        let { node, hub } = path;
+        let { node, hub, parent } = path;
         let { name } = node;
         let { file } = hub;
-        if (specified[name]) {
+        if (specified[name] && t.isExpression(parent) && !t.isMemberExpression(parent)) {
           let newNode = importMethod(specified[name], file);
           path.replaceWith({ type: newNode.type, name: newNode.name });
         }

--- a/test/fixtures/ramda-mixed-native/actual.js
+++ b/test/fixtures/ramda-mixed-native/actual.js
@@ -1,0 +1,15 @@
+import {map, add} from 'ramda';
+
+let mapper = map(add(1));
+
+mapper([1, 2, 3]);
+
+[1, 2, 3].map(a => a + 1);
+
+var obj = {
+	map: 1
+};
+
+var obj1 = {
+	[add]: 2
+};

--- a/test/fixtures/ramda-mixed-native/expected.js
+++ b/test/fixtures/ramda-mixed-native/expected.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var _add = require('ramda/src/add');
+
+var _add2 = _interopRequireDefault(_add);
+
+var _map = require('ramda/src/map');
+
+var _map2 = _interopRequireDefault(_map);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var mapper = (0, _map2.default)((0, _add2.default)(1));
+
+mapper([1, 2, 3]);
+
+[1, 2, 3].map(function (a) {
+	return a + 1;
+});
+
+var obj = {
+	map: 1
+};
+
+var obj1 = _defineProperty({}, _add2.default, 2);


### PR DESCRIPTION
Replace all Identifier in file is not correct. Example:
```js
import { map } from 'ramda';
map(a => a + 1, [1, 2, 3]);
[1,2,3].map(a => a + 1);
```
Expected: First `map` should be replace with import specifier, but second `map` should not be replaced.
Actual: Both `map` is replaced.
