### PR TITLE
bugfix(index.js): fix property rewriting

### DIFF
--- a/test/fixtures/ramda-mixed-native/actual.js
+++ b/test/fixtures/ramda-mixed-native/actual.js
@@ -13,3 +13,13 @@ var obj = {
 var obj1 = {
 	[add]: 2
 };
+
+var ob2 = {
+    rate: add
+};
+
+function test(param = map) {
+    return param;
+}
+
+var test1 = (param2 = add) => add;

--- a/test/fixtures/ramda-mixed-native/expected.js
+++ b/test/fixtures/ramda-mixed-native/expected.js
@@ -17,11 +17,26 @@ var mapper = (0, _map2.default)((0, _add2.default)(1));
 mapper([1, 2, 3]);
 
 [1, 2, 3].map(function (a) {
-	return a + 1;
+  return a + 1;
 });
 
 var obj = {
-	map: 1
+  map: 1
 };
 
 var obj1 = _defineProperty({}, _add2.default, 2);
+
+var ob2 = {
+  rate: _add2.default
+};
+
+function test() {
+  var param = arguments.length <= 0 || arguments[0] === undefined ? _map2.default : arguments[0];
+
+  return param;
+}
+
+var test1 = function test1() {
+  var param2 = arguments.length <= 0 || arguments[0] === undefined ? _add2.default : arguments[0];
+  return _add2.default;
+};


### PR DESCRIPTION
@megawac sorry, my previous fix has a bug because `Property` is not `Expression`(see test case for this https://github.com/typeetfunc/babel-plugin-ramda/blob/master/test/fixtures/ramda-mixed-native/actual.js#L17).