### PR TITLE
repeated identifier references in arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "WTFPL",
   "devDependencies": {
     "babel-cli": "^6.4.5",
-    "babel-core": "^6.4.5",
+    "babel-core": "^6.16.0",
     "babel-preset-es2015": "^6.3.13",
     "mocha": "^2.2.5"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export default function({ types: t }) {
       let path = resolveModule(methodName);
       selectedMethods[methodName] = file.addImport(path, 'default');
     }
-    return selectedMethods[methodName];
+    return t.clone(selectedMethods[methodName]);
   }
 
   return {

--- a/test/fixtures/ramda-mixed-native/expected.js
+++ b/test/fixtures/ramda-mixed-native/expected.js
@@ -31,12 +31,12 @@ var ob2 = {
 };
 
 function test() {
-  var param = arguments.length <= 0 || arguments[0] === undefined ? _map2.default : arguments[0];
+  var param = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _map2.default;
 
   return param;
 }
 
 var test1 = function test1() {
-  var param2 = arguments.length <= 0 || arguments[0] === undefined ? _add2.default : arguments[0];
+  var param2 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _add2.default;
   return _add2.default;
 };

--- a/test/fixtures/repeated-arguments/actual.js
+++ b/test/fixtures/repeated-arguments/actual.js
@@ -1,0 +1,3 @@
+import {compose, merge} from 'ramda';
+
+compose(merge, merge);

--- a/test/fixtures/repeated-arguments/expected.js
+++ b/test/fixtures/repeated-arguments/expected.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var _merge = require('ramda/src/merge');
+
+var _merge2 = _interopRequireDefault(_merge);
+
+var _compose = require('ramda/src/compose');
+
+var _compose2 = _interopRequireDefault(_compose);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _compose2.default)(_merge2.default, _merge2.default);


### PR DESCRIPTION
 - Fix for repeated identifier references in arguments (babel/babel#4396)
 - Fix ramda-mixed-native tests for new default param syntax (babel/babel/pull/4515)