### PR TITLE
Only rewrite bindings to ramda functions

### DIFF
--- a/test/fixtures/scope-shadowing/actual.js
+++ b/test/fixtures/scope-shadowing/actual.js
@@ -1,0 +1,12 @@
+import R, { prop as foo } from 'ramda';
+
+function bar(R, prop, foo) {
+  R.prop(foo);
+  foo;
+  foo();
+}
+function baz() {
+  R.prop(foo);
+  foo;
+  foo();
+}

--- a/test/fixtures/scope-shadowing/expected.js
+++ b/test/fixtures/scope-shadowing/expected.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var _prop = require('ramda/src/prop');
+
+var _prop2 = _interopRequireDefault(_prop);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function bar(R, prop, foo) {
+  R.prop(foo);
+  foo;
+  foo();
+}
+function baz() {
+  (0, _prop2.default)(_prop2.default);
+  _prop2.default;
+  (0, _prop2.default)();
+}


### PR DESCRIPTION
The changes make sure this:
```js
import R, { prop as foo } from 'ramda';

function bar(R, prop, foo) {
  R.prop(foo);
  foo;
  foo();
}
```
will not give this:
```js
'use strict';
var _prop = require('ramda/src/prop');
var _prop2 = _interopRequireDefault(_prop);
function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

function bar(R, prop, _default) {
  (0, _prop2.default)(_prop2.default);
  _prop2.default;
  (0, _prop2.default)();
}
```