### PR TITLE
Move ramda to peer & dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "babel-cli": "^6.4.5",
     "babel-core": "^6.16.0",
     "babel-preset-es2015": "^6.3.13",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "ramda": "^0.23.0"
+  },
+  "peerDependencies": {
+    "ramda": "0.x"
   },
   "scripts": {
     "build": "rm -rf lib && babel src --out-dir lib",
@@ -21,9 +25,6 @@
     "modularize",
     "babel-plugin"
   ],
-  "dependencies": {
-    "ramda": "^0.19.1"
-  },
   "babel": {
     "presets": [
       "es2015"


### PR DESCRIPTION
Ramda is required in order for the tests to run, so it needs to be included
as a devDep. Moving it to a peer dependency allows consumers to specify
which version of ramda to use without downloading extra versions. "0.x" as
the version constraint includes all the current 0.x versions, whereas "^0.19.0"
would only include versions in the provided minor range because ramda
hasn't hit 1.0 yet.

Fixes #17.