### PR TITLE
Move ramda to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "mocha": "^2.2.5",
     "ramda": "^0.23.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "ramda": "0.x"
   },
   "scripts": {


### PR DESCRIPTION
The plugin assumes that ramda is always installed. Projects without ramda produces an error. Hence it cant be in a higher level preset. 

I have a preset that uses babel-plugin-ramda, which is shared across multiple projects, some with ramda and some without. Latter projects throws error because ramda is not installed.

Eg of a preset
````
module.exports = {
  presets: [
    require('babel-preset-es2015'),
    require('babel-preset-react'),
    require('babel-preset-stage-0')
  ],
  plugins: [
    require("babel-plugin-ramda").default
  ]
}
````