### PR TITLE
test(specifier-alias): Correct alias test fixtures

### DIFF
--- a/test/fixtures/specifier-alias/actual.js
+++ b/test/fixtures/specifier-alias/actual.js
@@ -1,5 +1,6 @@
 import {add, map as map1} from 'ramda';
 
-let mapper = map(add(1));
+let map = () => {};
+let mapper = map(map1(add(1)));
 
 mapper([1, 2, 3]);

--- a/test/fixtures/specifier-alias/expected.js
+++ b/test/fixtures/specifier-alias/expected.js
@@ -4,8 +4,13 @@ var _add = require('ramda/src/add');
 
 var _add2 = _interopRequireDefault(_add);
 
+var _map = require('ramda/src/map');
+
+var _map2 = _interopRequireDefault(_map);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var mapper = map((0, _add2.default)(1));
+var map = function map() {};
+var mapper = map((0, _map2.default)((0, _add2.default)(1)));
 
 mapper([1, 2, 3]);


### PR DESCRIPTION
`map` is being imported as alias `map1` but `map` was still being used in the file. This changes `map` to be used as `map1` and also includes a locally defined `map` to ensure they are still differentiated inside the expected result. 

Also question, the `everything-es2015-module` tests don't seem to doing anything but failing and are causing a lot of noise in the tests... could they be muted? 