### PR TITLE
add useES option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Babel v5 is no longer supported. Use [v0.1.2](https://github.com/megawac/babel-p
 }
 ```
 
+or
+```json
+{
+  "plugins": [
+    ["ramda", {
+      "useES": true
+    }]
+  ]
+}
+```
+
+to use the new `ramda/es/` path for imports, which is available since Ramda 0.25. This is recommended as it uses ES modules rather than CommonJS. It defaults to `ramda/src/` when omitted.
+
 ###### Via CLI
 
 ```sh

--- a/src/modules.js
+++ b/src/modules.js
@@ -17,15 +17,17 @@ const _ramdaPath = path.dirname(Module._resolveFilename('ramda', merge(new Modul
 // ramda folder will be /nodemodules/ramda/dist. We want to remove the dist
 const ramdaPath = _ramdaPath.slice(0, _ramdaPath.lastIndexOf('ramda') + 5);
 
+// We do not need to change the search path based on useES since src and es are both built from the
+// same source in Ramda, and the directories will therefore always have identical contents.
 var methods = fs.readdirSync(path.join(ramdaPath, 'src'))
     .filter(name => path.extname(name) == '.js')
     .map(name => path.basename(name, '.js'));
 
-export default function resolveModule(name) {
+export default function resolveModule(useES, name) {
 
   for (var category in methods) {
     if (contains(name, methods)) {
-      return `ramda/src/${name}`;
+      return `ramda/${useES ? 'es' : 'src'}/${name}`;
     }
   }
   throw new Error(`Ramda method ${name} was not a known function

--- a/test/index.js
+++ b/test/index.js
@@ -14,12 +14,26 @@ describe("Ramda modularized builds", () => {
     const actualFile = path.join(fixtureDir, "actual.js");
     const expectedFile = path.join(fixtureDir, "expected.js");
 
-    it(`should work with ${caseName.split("-").join(" ")}`, () => {
-      const actual = transformFileSync(actualFile, {
-        plugins: [plugin]
-      }).code;
-      const expected = fs.readFileSync(expectedFile).toString();
-      assert.equal(trim(actual), trim(expected));
+    describe(`should work with ${caseName.split("-").join(" ")}`, () => {
+      // Programatically test with the useES option both on and off
+      specify('src', () => {
+        const actual = transformFileSync(actualFile, {
+          plugins: [plugin]
+        }).code;
+        const expected = fs.readFileSync(expectedFile).toString();
+        assert.equal(trim(actual), trim(expected));
+      });
+
+      specify('es', () => {
+        const actual = transformFileSync(actualFile, {
+          plugins: [[plugin, { "useES": true }]]
+        }).code;
+
+        // The only difference is that src should be replaced with es. This way, no changes to
+        // the tests are needed to cover testing of useES.
+        const expected = fs.readFileSync(expectedFile).toString().replace(/src/g, 'es');
+        assert.equal(trim(actual), trim(expected));
+      });
     });
   });
 


### PR DESCRIPTION
Provides an option to use the new `ramda/es` path as discussed in #31.  Added tests that should cover all the changes by running every non-error fixture test for both `useES` on and off.  

You mentioned something about some untranspiled code, but by what I can gather from the Ramda repository, this should suffice.