### PR TITLE
Restore automatic nullification of R literal.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ export default function({ types: t }) {
               ramdas[spec.local.name] = true;
             }
           });
+          path.replaceWith(t.nullLiteral())
           removablePaths.push(path);
         }
       },
@@ -133,6 +134,10 @@ export default function({ types: t }) {
         if (matchesRamdaMethod(path, name) && !isSpecialTypes(t, parent)) {
           let newNode = importMethod(useES, specified[name], hub.file);
           path.replaceWith({ type: newNode.type, name: newNode.name });
+        } else if (matchesRamda(path, name)) {
+          // #19, nullify direct references to the ramda import (for apply/spread/etc)
+          let replacementNode = t.nullLiteral();
+          path.replaceWith(replacementNode);
         }
       }
     }

--- a/test/fixtures/multi-mix-usage/expected.js
+++ b/test/fixtures/multi-mix-usage/expected.js
@@ -4,13 +4,13 @@ var _reject2 = require('ramda/src/reject');
 
 var _reject3 = _interopRequireDefault(_reject2);
 
-var _add2 = require('ramda/src/add');
-
-var _add3 = _interopRequireDefault(_add2);
-
 var _take2 = require('ramda/src/take');
 
 var _take3 = _interopRequireDefault(_take2);
+
+var _add2 = require('ramda/src/add');
+
+var _add3 = _interopRequireDefault(_add2);
 
 var _map2 = require('ramda/src/map');
 

--- a/test/fixtures/multi-specifier/expected.js
+++ b/test/fixtures/multi-specifier/expected.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var _take2 = require('ramda/src/take');
-
-var _take3 = _interopRequireDefault(_take2);
-
 var _reject2 = require('ramda/src/reject');
 
 var _reject3 = _interopRequireDefault(_reject2);
 
-var _map2 = require('ramda/src/map');
+var _take2 = require('ramda/src/take');
 
-var _map3 = _interopRequireDefault(_map2);
+var _take3 = _interopRequireDefault(_take2);
 
 var _add2 = require('ramda/src/add');
 
 var _add3 = _interopRequireDefault(_add2);
+
+var _map2 = require('ramda/src/map');
+
+var _map3 = _interopRequireDefault(_map2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/test/fixtures/nullifies-identifier-references/actual.js
+++ b/test/fixtures/nullifies-identifier-references/actual.js
@@ -1,0 +1,7 @@
+import R from 'ramda';
+
+// issue #19
+const resultA = R.pipe(R.inc, R.inc)(1);
+const resultB = R.pipe(...[R.inc, R.inc])(1);
+const resultC = R.pipe.call(R, R.inc, R.inc)(1);
+const resultD = R.pipe.apply(R, [R.inc, R.inc])(1);

--- a/test/fixtures/nullifies-identifier-references/expected.js
+++ b/test/fixtures/nullifies-identifier-references/expected.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var _inc = require('ramda/src/inc');
+var _inc2 = require('ramda/src/inc');
 
-var _inc2 = _interopRequireDefault(_inc);
+var _inc3 = _interopRequireDefault(_inc2);
 
-var _pipe = require('ramda/src/pipe');
+var _pipe2 = require('ramda/src/pipe');
 
-var _pipe2 = _interopRequireDefault(_pipe);
+var _pipe3 = _interopRequireDefault(_pipe2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // issue #19
-var resultA = (0, _pipe2.default)(_inc2.default, _inc2.default)(1);
-var resultB = _pipe2.default.apply(null, [_inc2.default, _inc2.default])(1);
-var resultC = _pipe2.default.call(null, _inc2.default, _inc2.default)(1);
-var resultD = _pipe2.default.apply(null, [_inc2.default, _inc2.default])(1);
+var resultA = (0, _pipe3.default)(_inc3.default, _inc3.default)(1);
+var resultB = _pipe3.default.apply(null, [_inc3.default, _inc3.default])(1);
+var resultC = _pipe3.default.call(null, _inc3.default, _inc3.default)(1);
+var resultD = _pipe3.default.apply(null, [_inc3.default, _inc3.default])(1);

--- a/test/fixtures/nullifies-identifier-references/expected.js
+++ b/test/fixtures/nullifies-identifier-references/expected.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var _inc = require('ramda/src/inc');
+
+var _inc2 = _interopRequireDefault(_inc);
+
+var _pipe = require('ramda/src/pipe');
+
+var _pipe2 = _interopRequireDefault(_pipe);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// issue #19
+var resultA = (0, _pipe2.default)(_inc2.default, _inc2.default)(1);
+var resultB = _pipe2.default.apply(null, [_inc2.default, _inc2.default])(1);
+var resultC = _pipe2.default.call(null, _inc2.default, _inc2.default)(1);
+var resultD = _pipe2.default.apply(null, [_inc2.default, _inc2.default])(1);

--- a/test/fixtures/specifier-alias/expected.js
+++ b/test/fixtures/specifier-alias/expected.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var _map2 = require('ramda/src/map');
-
-var _map3 = _interopRequireDefault(_map2);
-
 var _add2 = require('ramda/src/add');
 
 var _add3 = _interopRequireDefault(_add2);
+
+var _map2 = require('ramda/src/map');
+
+var _map3 = _interopRequireDefault(_map2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/test/fixtures/specifier-usage/expected.js
+++ b/test/fixtures/specifier-usage/expected.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var _map2 = require('ramda/src/map');
-
-var _map3 = _interopRequireDefault(_map2);
-
 var _add2 = require('ramda/src/add');
 
 var _add3 = _interopRequireDefault(_add2);
+
+var _map2 = require('ramda/src/map');
+
+var _map3 = _interopRequireDefault(_map2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 


### PR DESCRIPTION
This restores the fix for #19, allowing the spread operator to be used as expected. It also trues up some assorted weirdnesses in the tests that cropped up after the change.