### PR TITLE
Swap contains with includes

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -3,13 +3,6 @@ import fs from 'fs';
 import Module from 'module';
 import path from 'path';
 
-function getDirectories(srcPath) {
-  // Slow synchronous version of https://github.com/megawac/lodash-modularize/blob/master/src/lodashModules.js.
-  // Using the paths lodash-cli provides is not an option as they may change version to version =(
-  return ['.'].concat(fs.readdirSync(srcPath)).filter(filePath =>
-    fs.statSync(path.join(srcPath, filePath)).isDirectory());
-}
-
 const _ramdaPath = path.dirname(Module._resolveFilename('ramda', mergeRight(new Module, {
   'paths': Module._nodeModulePaths(process.cwd())
 })));
@@ -19,17 +12,15 @@ const ramdaPath = _ramdaPath.slice(0, _ramdaPath.lastIndexOf('ramda') + 5);
 
 // We do not need to change the search path based on useES since src and es are both built from the
 // same source in Ramda, and the directories will therefore always have identical contents.
-var methods = fs.readdirSync(path.join(ramdaPath, 'src'))
-    .filter(name => path.extname(name) == '.js')
-    .map(name => path.basename(name, '.js'));
+const methods = fs.readdirSync(path.join(ramdaPath, 'src'))
+  .filter(name => path.extname(name) === '.js')
+  .map(name => path.basename(name, '.js'));
 
 export default function resolveModule(useES, name) {
-
-  for (var category in methods) {
-    if (contains(name, methods)) {
-      return `ramda/${useES ? 'es' : 'src'}/${name}`;
-    }
+  if (contains(name, methods)) {
+    return `ramda/${useES ? 'es' : 'src'}/${name}`;
   }
+
   throw new Error(`Ramda method ${name} was not a known function
     Please file a bug if it's my fault https://github.com/megawac/babel-plugin-ramda/issues
   `);

--- a/src/modules.js
+++ b/src/modules.js
@@ -1,4 +1,4 @@
-import {contains, mergeRight} from 'ramda';
+import {includes, mergeRight} from 'ramda';
 import fs from 'fs';
 import Module from 'module';
 import path from 'path';
@@ -17,7 +17,7 @@ const methods = fs.readdirSync(path.join(ramdaPath, 'src'))
   .map(name => path.basename(name, '.js'));
 
 export default function resolveModule(useES, name) {
-  if (contains(name, methods)) {
+  if (includes(name, methods)) {
     return `ramda/${useES ? 'es' : 'src'}/${name}`;
   }
 


### PR DESCRIPTION
The contains function was deprecated in a later version of ramda. This PR updates the package to use the suggested replacement and cleans up some (seemingly) unused code.